### PR TITLE
Security update 

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -1,5 +1,5 @@
 let { WA_MESSAGE_STUB_TYPES,  MessageType  } = require('@adiwajshing/baileys')
-let urlRegex = require('url-regex')({ strict: false })
+let urlRegex = require('url-regex-safe')({ strict: false })
 let PhoneNumber = require('awesome-phonenumber')
 let terminalImage = global.opts['img'] ? require('terminal-image') : ''
 let chalk = require('chalk')

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@adiwajshing/baileys": "github:adiwajshing/baileys",
     "awesome-phonenumber": "^2.47.0",
-    "ansi-regex": "^5.0.1",
     "brainly-scraper-v2": "^1.1.2",
     "cfonts": "^2.9.3",
     "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@adiwajshing/baileys": "github:adiwajshing/baileys",
     "awesome-phonenumber": "^2.47.0",
+    "ansi-regex": "^5.0.1",
     "brainly-scraper-v2": "^1.1.2",
     "cfonts": "^2.9.3",
     "chalk": "^4.1.0",
@@ -61,7 +62,7 @@
     "syntax-error": "^1.4.0",
     "terminal-image": "^1.2.1",
     "translate-google-api": "^1.0.4",
-    "url-regex": "^5.0.0",
+    "url-regex-safe": "^2.1.0",
     "xmldom": "github:xmldom/xmldom#0.7.0",
     "warn": "^1.0.1",
     "yargs": "^16.2.0",


### PR DESCRIPTION
2 fixes:

CVE-2021-3807
moderate severity
Vulnerable versions: > 2.1.1, < 5.0.1
Patched version: 5.0.1
ansi-regex is vulnerable to Inefficient Regular Expression Complexity
---
CVE-2020-7661
high severity
Vulnerable versions: <= 5.0.0
Patched version: No fix
all versions of url-regex are vulnerable to Regular Expression Denial of Service. An attacker providing a very long string in String.test can cause a Denial of Service.