### PR TITLE
Fix error for termux user

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "license": "GPL-3.0-or-later",
     "dependencies": {
-        "@adiwajshing/baileys": "github:adiwajshing/baileys",
+        "@adiwajshing/baileys": "^4.0.1",
         "@bochilteam/scraper": "^1.0.2",
         "awesome-phonenumber": "^2.68.0",
         "axios": "^0.24.0",


### PR DESCRIPTION
It will fix "Baileys/lib modules not found" for termux users.