### PR TITLE
Move to baileys stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "license": "GPL-3.0-or-later",
     "dependencies": {
-        "@adiwajshing/baileys": "4.0.1",
+        "@adiwajshing/baileys": "^4.1.0",
         "@bochilteam/scraper": "^2.0.0",
         "awesome-phonenumber": "^2.68.0",
         "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "license": "GPL-3.0-or-later",
     "dependencies": {
-        "@adiwajshing/baileys": "github:adiwajshing/baileys",
+        "@adiwajshing/baileys": "4.0.1",
         "@bochilteam/scraper": "^2.0.0",
         "awesome-phonenumber": "^2.68.0",
         "axios": "^0.24.0",


### PR DESCRIPTION
Move to Baileys stable version.

Unstable baileys cause Termux user to show "@adiwajshing/baileys/ modules not found".

Keep version "@adiwajshing/baileys" "<blank>" or "^4.0.1"